### PR TITLE
add hacky potentially working zone transfers

### DIFF
--- a/ct_backend/settings/dns.py
+++ b/ct_backend/settings/dns.py
@@ -3,6 +3,9 @@ import os
 DNS_BASE_DOMAIN = os.environ.get('DNS_BASE_DOMAIN', ".")
 DNS_CONTAINER_DOMAIN = os.environ.get('DNS_CONTAINER_DOMAIN', ".")
 DNS_MIRROR_SERVER = os.environ.get('DNS_MIRROR_SERVER', "").strip()
+DNS_ALLOW_TRANSFER = os.environ.get('DNS_ALLOW_TRANSFER', "").strip()
 print("forwarding requests to: %s" % DNS_MIRROR_SERVER)
 if DNS_MIRROR_SERVER == "":
     DNS_MIRROR_SERVER = None
+if DNS_ALLOW_TRANSFER == "":
+    DNS_ALLOW_TRANSFER = None


### PR DESCRIPTION
Partially tested code to support zone transfers when enabled. The default is to not support them, which can be changed for requests originating from an allowed network (`DNS_ALLOW_TRANSFER=123.234.0.0/16`).

This would be useful In deployments where the DNS server has to act as a hidden primary, e.g., to be deployed behind a more capable DNS server with DNSSEC support 😉 